### PR TITLE
Empty Element Prior to $0 Span

### DIFF
--- a/footer_html_pilot_24FEB2017.js
+++ b/footer_html_pilot_24FEB2017.js
@@ -1,6 +1,8 @@
 $(document).ready(function(){
 	
-	$( "span:contains('$0.00')" ).empty();
+	$( "span:contains('$0.00')" ).prev().empty();
+
+	$("span:contains('$0.00')").empty();
 	
 	$("[aria-labelledby=Support]").empty();
 	


### PR DESCRIPTION
Attempt at removing "Price" from $0.00 items. This may incorrectly remove estimated time from 1st instance of $0.00 in training details header.